### PR TITLE
feat(iOS): resolve full authorization details and improved typings

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,10 @@ signInWithApple(
         // by default you don't get these details, but if you provide these scopes you will (and the user will get to choose which ones are allowed)
         scopes: ["EMAIL", "FULLNAME"]
     })
-    .then(credential => {
-        console.log("Signed in, user: " + credential.user);
-        // you can remembed the user to check the sign in state later (see 'getSignInWithAppleState' below)
-        this.user = credential.user;
+    .then(result => {
+        console.log("Signed in credential: " + result.credential);
+        // you can remember the user to check the sign in state later (see 'getSignInWithAppleState' below)
+        this.user = result.credential.user;
     })
     .catch(err => console.log("Error signing in: " + err));
 ```

--- a/src/apple-sign-in.ios.ts
+++ b/src/apple-sign-in.ios.ts
@@ -1,19 +1,31 @@
 import { device } from "tns-core-modules/platform";
 import { ios as iOSUtils } from "tns-core-modules/utils/utils";
-import { SignInWithAppleCredentials, SignInWithAppleOptions, SignInWithAppleState } from "./index";
+import {
+  SignInWithAppleAuthorization,
+  SignInWithAppleOptions,
+  SignInWithAppleState,
+  SignInWithAppleUserDetectionStatus,
+  SignInWithAppleCredential
+} from "./index";
 import jsArrayToNSArray = iOSUtils.collections.jsArrayToNSArray;
+import nsArrayToJSArray = iOSUtils.collections.nsArrayToJSArray;
 
 let controller: any /* ASAuthorizationController */;
 let delegate: ASAuthorizationControllerDelegateImpl;
 
-declare const ASAuthorizationAppleIDProvider, ASAuthorizationController, ASAuthorizationControllerDelegate,
-    ASAuthorizationScopeEmail, ASAuthorizationScopeFullName: any;
+declare const ASAuthorizationAppleIDProvider,
+  ASAuthorizationController,
+  ASAuthorizationControllerDelegate,
+  ASAuthorizationScopeEmail,
+  ASAuthorizationScopeFullName: any;
 
 export function isSignInWithAppleSupported(): boolean {
   return parseInt(device.osVersion) >= 13;
 }
 
-export function getSignInWithAppleState(user: string): Promise<SignInWithAppleState> {
+export function getSignInWithAppleState(
+  user: string
+): Promise<SignInWithAppleState> {
   return new Promise<any>((resolve, reject) => {
     if (!user) {
       reject("The 'user' parameter is mandatory");
@@ -26,27 +38,39 @@ export function getSignInWithAppleState(user: string): Promise<SignInWithAppleSt
     }
 
     const provider = ASAuthorizationAppleIDProvider.new();
-    provider.getCredentialStateForUserIDCompletion(user, (state: any /* enum: ASAuthorizationAppleIDProviderCredentialState */, error: NSError) => {
+    provider.getCredentialStateForUserIDCompletion(user, (
+      state: any /* enum: ASAuthorizationAppleIDProviderCredentialState */,
+      error: NSError
+    ) => {
       if (error) {
         reject(error.localizedDescription);
         return;
       }
 
-      if (state === 1) { // ASAuthorizationAppleIDProviderCredential.Authorized
+      if (state === 1) {
+        // ASAuthorizationAppleIDProviderCredential.Authorized
         resolve("AUTHORIZED");
-      } else if (state === 2) { // ASAuthorizationAppleIDProviderCredential.NotFound
+      } else if (state === 2) {
+        // ASAuthorizationAppleIDProviderCredential.NotFound
         resolve("NOTFOUND");
-      } else if (state === 3) { // ASAuthorizationAppleIDProviderCredential.Revoked
+      } else if (state === 3) {
+        // ASAuthorizationAppleIDProviderCredential.Revoked
         resolve("REVOKED");
       } else {
         // this prolly means a state was added so we need to add it to the plugin
-        reject("Invalid state for getSignInWithAppleState: " + state + ", please report an issue at he plugin repo!");
+        reject(
+          "Invalid state for getSignInWithAppleState: " +
+            state +
+            ", please report an issue at he plugin repo!"
+        );
       }
     });
   });
 }
 
-export function signInWithApple(options?: SignInWithAppleOptions): Promise<SignInWithAppleCredentials> {
+export function signInWithApple(
+  options?: SignInWithAppleOptions
+): Promise<SignInWithAppleAuthorization> {
   return new Promise<any>((resolve, reject) => {
     if (!isSignInWithAppleSupported()) {
       reject("Not supported");
@@ -68,14 +92,21 @@ export function signInWithApple(options?: SignInWithAppleOptions): Promise<SignI
         } else if (s === "FULLNAME") {
           nsArray.addObject(ASAuthorizationScopeFullName);
         } else {
-          console.log("Unsupported scope: " + s + ", use either EMAIL or FULLNAME");
+          console.log(
+            "Unsupported scope: " + s + ", use either EMAIL or FULLNAME"
+          );
         }
       });
       request.requestedScopes = nsArray;
     }
 
-    controller = ASAuthorizationController.alloc().initWithAuthorizationRequests(jsArrayToNSArray([request]));
-    controller.delegate = delegate = ASAuthorizationControllerDelegateImpl.createWithPromise(resolve, reject);
+    controller = ASAuthorizationController.alloc().initWithAuthorizationRequests(
+      jsArrayToNSArray([request])
+    );
+    controller.delegate = delegate = ASAuthorizationControllerDelegateImpl.createWithPromise(
+      resolve,
+      reject
+    );
     controller.performRequests();
   });
 }
@@ -87,16 +118,25 @@ class ASAuthorizationControllerDelegateImpl extends NSObject /* implements ASAut
 
   public static new(): ASAuthorizationControllerDelegateImpl {
     try {
-      ASAuthorizationControllerDelegateImpl.ObjCProtocols.push(ASAuthorizationControllerDelegate);
+      ASAuthorizationControllerDelegateImpl.ObjCProtocols.push(
+        ASAuthorizationControllerDelegate
+      );
       return <ASAuthorizationControllerDelegateImpl>super.new();
     } catch (ignore) {
-      console.log("Apple Sign In not supported on this device - it requires iOS 13+. Tip: use 'isSignInWithAppleSupported' before calling 'signInWithApple'.");
+      console.log(
+        "Apple Sign In not supported on this device - it requires iOS 13+. Tip: use 'isSignInWithAppleSupported' before calling 'signInWithApple'."
+      );
       return null;
     }
   }
 
-  public static createWithPromise(resolve, reject): ASAuthorizationControllerDelegateImpl {
-    const delegate = <ASAuthorizationControllerDelegateImpl>ASAuthorizationControllerDelegateImpl.new();
+  public static createWithPromise(
+    resolve,
+    reject
+  ): ASAuthorizationControllerDelegateImpl {
+    const delegate = <ASAuthorizationControllerDelegateImpl>(
+      ASAuthorizationControllerDelegateImpl.new()
+    );
     if (delegate === null) {
       reject("Not supported");
     } else {
@@ -106,27 +146,72 @@ class ASAuthorizationControllerDelegateImpl extends NSObject /* implements ASAut
     return delegate;
   }
 
-  authorizationControllerDidCompleteWithAuthorization(controller: any /* ASAuthorizationController */, authorization: any /* ASAuthorization */): void {
-    console.log(">>> credential.state: " + authorization.credential.state); // string
-
-    // these properties don't seem useful for now
-    // const authCode = NSString.alloc().initWithDataEncoding(authorization.credential.authorizationCode, NSUTF8StringEncoding);
-    // console.log(">>> credential.identityToken: " + authorization.credential.identityToken); // nsdata
-
-    // These require a scope
-    // console.log(">>> credential.fullName: " + authorization.credential.fullName); // NSPersonNameComponents (familyName, etc)
-    // console.log(">>> credential.email: " + authorization.credential.email); // string
-
-    // console.log(">>> credential.realUserStatus: " + authorization.credential.realUserStatus); // enum
-
-    // TODO return granted scopes
-    this.resolve(<SignInWithAppleCredentials>{
-      user: authorization.credential.user,
-      // scopes: authorization.credential.authorizedScopes // nsarray<asauthorizationscope>
-    });
+  authorizationControllerDidCompleteWithAuthorization(
+    controller: any /* ASAuthorizationController */,
+    authorization: {
+      provider: any;
+      credential: SignInWithAppleCredential & {
+        accessToken?: NSData;
+        authenticatedResponse?: NSHTTPURLResponse;
+        authorizationCode?: NSData;
+        authorizedScopes?: NSArray<string>;
+        identityToken?: NSData;
+      };
+    }
+  ): void {
+    if (authorization && authorization.credential) {
+      const data: SignInWithAppleAuthorization = {
+        provider: authorization.provider,
+        credential: {
+          // primitive data
+          email: authorization.credential.email,
+          fullName: authorization.credential.fullName,
+          realUserStatus: authorization.credential.realUserStatus,
+          state: authorization.credential.state,
+          user: authorization.credential.user,
+          password: authorization.credential.password
+        }
+      };
+      // then in addition for added convenience, convert some native objects to friendly js
+      if (authorization.credential.accessToken) {
+        data.credential.accessToken = <string>(<unknown>NSString.alloc()
+          .initWithDataEncoding(
+            authorization.credential.accessToken,
+            NSUTF8StringEncoding
+          )
+          .toString());
+      }
+      if (authorization.credential.authorizationCode) {
+        data.credential.authorizationCode = <string>(<unknown>NSString.alloc()
+          .initWithDataEncoding(
+            authorization.credential.authorizationCode,
+            NSUTF8StringEncoding
+          )
+          .toString());
+      }
+      if (authorization.credential.authorizedScopes) {
+        data.credential.authorizedScopes = nsArrayToJSArray(
+          authorization.credential.authorizedScopes
+        );
+      }
+      if (authorization.credential.identityToken) {
+        data.credential.identityToken = <string>(<unknown>NSString.alloc()
+          .initWithDataEncoding(
+            authorization.credential.identityToken,
+            NSUTF8StringEncoding
+          )
+          .toString());
+      }
+      this.resolve(data);
+    } else {
+      this.reject("auth error: no credential returned.");
+    }
   }
 
-  authorizationControllerDidCompleteWithError(controller: any /* ASAuthorizationController */, error: NSError): void {
+  authorizationControllerDidCompleteWithError(
+    controller: any /* ASAuthorizationController */,
+    error: NSError
+  ): void {
     this.reject(error.localizedDescription);
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,13 +7,50 @@ export declare interface SignInWithAppleOptions {
   scopes?: Array<SignInWithAppleScope>;
 }
 
-export declare interface SignInWithAppleCredentials {
-  user: string;
-  // scopes: Array<SignInWithAppleScope>;
+// convenient enum based on ASUserDetectionStatus (XCode 11+)
+export declare const enum SignInWithAppleUserDetectionStatus {
+  Unsupported = 0,
+  Unknown = 1,
+  LikelyReal = 2
+}
+
+export declare interface SignInWithAppleName {
+  familyName?: string;
+  givenName?: string;
+  middleName?: string;
+  namePrefix?: string;
+  nameSuffix?: string;
+  nickname?: string;
+  phoneticRepresentation?: SignInWithAppleName;
+}
+
+// This combines various interfaces of ASAuthorizationCredential types (XCode 11+)
+// user can parse data out depending on scopes used
+export interface SignInWithAppleCredential {
+  accessToken?: string;
+  authenticatedResponse?: any;
+  authorizationCode?: string;
+  authorizedScopes?: Array<string>;
+  email?: string;
+  fullName?: SignInWithAppleName;
+  identityToken?: string;
+  realUserStatus?: SignInWithAppleUserDetectionStatus;
+  state?: string;
+  user?: string;
+  password?: string;
+}
+
+export interface SignInWithAppleAuthorization {
+  credential: SignInWithAppleCredential;
+  provider: any; // TODO (can extract convenient typing for this)
 }
 
 export declare function isSignInWithAppleSupported(): boolean;
 
-export declare function getSignInWithAppleState(user: string): Promise<SignInWithAppleState>;
+export declare function getSignInWithAppleState(
+  user: string
+): Promise<SignInWithAppleState>;
 
-export declare function signInWithApple(options?: SignInWithAppleOptions): Promise<SignInWithAppleCredentials>;
+export declare function signInWithApple(
+  options?: SignInWithAppleOptions
+): Promise<SignInWithAppleAuthorization>;

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -20,8 +20,13 @@
         "noImplicitUseStrict": false,
         "noFallthroughCasesInSwitch": true
     },
+    "files": [
+        "./references.d.ts",
+        "./apple-sign-in.android.ts",
+        "./apple-sign-in.ios.ts"
+    ],
     "exclude": [
-        "node_modules"
+      "node_modules"
     ],
     "compileOnSave": false
 }


### PR DESCRIPTION
Turns out the **full** authorization details are extremely useful (if not required) by some varied backend integrations to use this. Also improved the typings a bit to account for the full details being resolved.