### PR TITLE
Fixed NS version in Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,6 @@ before_install:
     - sudo pip install six
 
 install:
-    - echo no | npm install -g nativescript
+    - echo no | npm install -g nativescript@5
     - tns usage-reporting disable
     - tns error-reporting disable


### PR DESCRIPTION
This plugin is not compatible with NS 6, so the CI fails. I just set NS 5 in Travis so PRs can be correctly checked and merged.